### PR TITLE
Apply the BabylonJS 5.1 RenderTargetTexture changes

### DIFF
--- a/src/textureCanvas.ts
+++ b/src/textureCanvas.ts
@@ -517,7 +517,7 @@ export class TextureCanvas extends RenderTargetTexture {
 
         // Update properties
         this._size = size;
-        this._generateMipMaps = false;
+        this._generateMipMaps = this._generateMipMaps;
     }
 
     /**


### PR DESCRIPTION
Proposal to fix Issue #2. Also applied some cosmetic changes to make ESLint happy :) 

It uses the latest changes to the render targets as documented on the BJS website: https://doc.babylonjs.com/whats-new

> Rework of the inner working of render targets. Those are mostly internal changes. From the end user standpoint, the most visible change is that the PostProcess class is now dealing with RenderTargetWrapper instead of InternalTexture objects. So, if you are directly updating the inputTexture property with a render target texture that you previously rendered, you will need to pass a RenderTargetWrapper instead of an InternalTexture: you will get it by doing rtt.renderTarget, where rtt is the instance of your RenderTargetTexture. [Popov72]
